### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [![Downloads](https://img.shields.io/npm/dm/mcp-3d-printer-server.svg)](https://www.npmjs.com/package/mcp-3d-printer-server)
 [![GitHub stars](https://img.shields.io/github/stars/yourusername/mcp-3d-printer-server.svg?style=social&label=Star)](https://github.com/yourusername/mcp-3d-printer-server)
 
+<a href="https://glama.ai/mcp/servers/7f6v2enbgk">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/7f6v2enbgk/badge" alt="3D Printer Server MCP server" />
+</a>
+
 ## Description
 
 This is a server that allows MCP users to connect with the API endpoints of these 3D Printers: 


### PR DESCRIPTION
This PR adds a badge for the [MCP 3D Printer Server](https://glama.ai/mcp/servers/7f6v2enbgk) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/7f6v2enbgk">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/7f6v2enbgk/badge" alt="3D Printer Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.