### PR TITLE
Remove top-level anyOf from upload_gcode inputSchema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -625,11 +625,7 @@ class ThreeDPrinterMCPServer {
                   type: "boolean",
                   description: "Start printing after upload when the printer backend supports it."
                 }
-              },
-              anyOf: [
-                { required: ["filename", "gcode"] },
-                { required: ["gcode_path"] }
-              ]
+              }
             }
           },
           {


### PR DESCRIPTION
Fixes #17.

`upload_gcode`'s `inputSchema` had `anyOf` at the top level (sibling of `properties`), which the Anthropic Messages API rejects with:

    tools.<N>.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level

The Anthropic API rejects the **entire** tool list at registration when any tool's schema is invalid, so this single block was disabling every tool the server exposed for Claude Code, Claude Desktop, and any other Anthropic-based MCP client.

## Change

`src/index.ts`: remove the four-line top-level `anyOf` block from `upload_gcode`'s `inputSchema`.

```diff
-                    },
-                    anyOf: [
-                        { required: ["filename", "gcode"] },
-                        { required: ["gcode_path"] }
-                    ]
+                    }
```

## Why this is safe

The runtime handler for `upload_gcode` already throws when neither `gcode` nor `gcode_path` is supplied, so the schema-level `anyOf` was redundant. Removing it doesn't relax validation — it just makes the input schema valid for Anthropic's tool API.

## Verification

- `npm ci` — clean.
- `npx -p typescript@5 tsc` — clean. (Heads-up: `npm run build` runs bare `tsc`, but `typescript` isn't in `devDependencies` on a clean clone; ran via `npx` here. Happy to add it in a separate PR if useful.)
- The same one-block removal has been running in my locally-installed `dist/index.js@1.2.5` since I patched it by hand, without issue.
- Code inspection: the runtime handler still throws when neither `gcode` nor `gcode_path` is supplied, so removing the schema-level constraint doesn't relax validation.
