### PR TITLE
Read bridge_command from env by default, with MCP_ALLOW_BRIDGE_COMMAND_ARG opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ ORCASLICER_BAMBULAB_PLUGIN_DIR=/path/to/FULU/OrcaSlicer.app/Contents/MacOS
 # /Users/you/Library/Application Support/OrcaSlicer/macos-bridge/runtime
 PJARCZAK_MAC_RUNTIME_DIR=
 FULU_BAMBU_BRIDGE_COMMAND=
+
+# Accept per-call bridge executable selectors instead of reading commands and
+# paths from server env. Includes bridge_command and active-probe path overrides.
+# Off by default.
+MCP_ALLOW_BRIDGE_COMMAND_ARG=false

--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ MCP_HTTP_ALLOWED_ORIGINS=http://localhost
 
 # Optional bridge command for blender_mcp_edit_model execute=true mode
 BLENDER_MCP_BRIDGE_COMMAND=
+
+# Accept per-call bridge executable selectors instead of reading commands and
+# paths from server environment configuration. Off by default: bridge_command
+# and active-probe slicer_path/plugin_dir/runtime_dir overrides can select which
+# local executable launches. Set to 1 for iterative FULU bridge diagnostics.
+MCP_ALLOW_BRIDGE_COMMAND_ARG=false
 ```
 
 ## Usage
@@ -392,6 +398,15 @@ Ask your MCP client to call `check_fulu_orca_setup`, or call it from an agent wi
 ```
 
 The result reports missing payload files, install/verify commands, the MCP env values to use, and bridge handshake/capability/runtime info when probing is enabled.
+
+> **Per-call executable selectors require `MCP_ALLOW_BRIDGE_COMMAND_ARG=1` for a live probe.**
+> By default the bridge command and its derived paths are read from server environment
+> configuration. Passing `bridge_command`, or passing `slicer_path`, `plugin_dir`, or
+> `runtime_dir` with `run_bridge_probe=true`, returns an error naming the opt-in flag.
+> Non-executing setup inspection can still use the path arguments without the flag. These values
+> select which local executable this server launches, so accepting them for a probe lets whatever
+> is steering the model — a downloaded model's description, a README in an archive, 3MF metadata —
+> choose that program. Set the flag for iterative bridge diagnostics; leave it off for normal use.
 
 #### FULU Bridge RPC
 
@@ -865,6 +880,8 @@ For Bambu printers, this dispatches firmware G-code temperature commands (`M104`
 #### check_fulu_orca_setup
 
 Inspects the FULU OrcaSlicer-bambulab executable, platform runtime payload, setup commands, and optional BambuNetwork bridge probe.
+
+The `bridge_command` shown below requires `MCP_ALLOW_BRIDGE_COMMAND_ARG=1`; otherwise it is read from `FULU_BAMBU_BRIDGE_COMMAND`. See [Check The Setup Through MCP](#check-the-setup-through-mcp).
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mcp-3d-printer-server",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mcp-3d-printer-server",
-            "version": "1.2.6",
+            "version": "1.2.7",
             "license": "GPL-2.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mcp-3d-printer-server",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "description": "MCP server for connecting Claude with 3D printer management systems",
     "main": "dist/index.js",
     "repository": "https://github.com/DMontgomery40/mcp-3D-printer-server",

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ type RuntimeConfig = {
   enableJsonResponse: boolean;
   allowedOrigins: Set<string>;
   blenderBridgeCommand?: string;
+  allowBridgeCommandArg: boolean;
 };
 
 function parseBooleanEnv(rawValue: string | undefined, fallback: boolean): boolean {
@@ -259,6 +260,7 @@ function readRuntimeConfig(): RuntimeConfig {
     enableJsonResponse: parseBooleanEnv(process.env.MCP_HTTP_JSON_RESPONSE, true),
     allowedOrigins: parseCsvEnv(process.env.MCP_HTTP_ALLOWED_ORIGINS),
     blenderBridgeCommand: process.env.BLENDER_MCP_BRIDGE_COMMAND?.trim() || undefined,
+    allowBridgeCommandArg: parseBooleanEnv(process.env.MCP_ALLOW_BRIDGE_COMMAND_ARG, false),
   };
 }
 
@@ -1173,15 +1175,23 @@ class ThreeDPrinterMCPServer {
               properties: {
                 slicer_path: {
                   type: "string",
-                  description: "Path to the FULU OrcaSlicer executable. Defaults from SLICER_PATH/FULU_ORCA_PATH."
+                  description:
+                    "Path to the FULU OrcaSlicer executable. Defaults from SLICER_PATH/FULU_ORCA_PATH. " +
+                    "When run_bridge_probe=true, requires MCP_ALLOW_BRIDGE_COMMAND_ARG=1 to be accepted here."
                 },
                 plugin_dir: {
                   type: "string",
-                  description: "Directory containing the FULU Bambu runtime payload; on macOS this is usually OrcaSlicer.app/Contents/MacOS."
+                  description:
+                    "Directory containing the FULU Bambu runtime payload; on macOS this is usually " +
+                    "OrcaSlicer.app/Contents/MacOS. When run_bridge_probe=true, requires " +
+                    "MCP_ALLOW_BRIDGE_COMMAND_ARG=1 to be accepted here."
                 },
                 runtime_dir: {
                   type: "string",
-                  description: "Installed runtime directory. On macOS this defaults to ~/Library/Application Support/OrcaSlicer/macos-bridge/runtime."
+                  description:
+                    "Installed runtime directory. On macOS this defaults to ~/Library/Application " +
+                    "Support/OrcaSlicer/macos-bridge/runtime. When run_bridge_probe=true, requires " +
+                    "MCP_ALLOW_BRIDGE_COMMAND_ARG=1 to be accepted here."
                 },
                 platform: {
                   type: "string",
@@ -1190,7 +1200,10 @@ class ThreeDPrinterMCPServer {
                 },
                 bridge_command: {
                   type: "string",
-                  description: "Command that starts the FULU BambuNetwork bridge host for probing."
+                  description:
+                    "Command that starts the FULU BambuNetwork bridge host for probing. Read from " +
+                    "FULU_BAMBU_BRIDGE_COMMAND by default; requires MCP_ALLOW_BRIDGE_COMMAND_ARG=1 " +
+                    "to be accepted here."
                 },
                 run_bridge_probe: {
                   type: "boolean",
@@ -1212,7 +1225,10 @@ class ThreeDPrinterMCPServer {
               properties: {
                 bridge_command: {
                   type: "string",
-                  description: "Command that starts the FULU BambuNetwork bridge host. Defaults to FULU_BAMBU_BRIDGE_COMMAND."
+                  description:
+                    "Command that starts the FULU BambuNetwork bridge host. Defaults to " +
+                    "FULU_BAMBU_BRIDGE_COMMAND; requires MCP_ALLOW_BRIDGE_COMMAND_ARG=1 to be " +
+                    "accepted here."
                 },
                 method: {
                   type: "string",
@@ -1303,7 +1319,10 @@ class ThreeDPrinterMCPServer {
                 },
                 bridge_command: {
                   type: "string",
-                  description: "Optional override command for invoking a local Blender MCP bridge."
+                  description:
+                    "Optional override command for invoking a local Blender MCP bridge. Read from " +
+                    "BLENDER_MCP_BRIDGE_COMMAND by default; requires MCP_ALLOW_BRIDGE_COMMAND_ARG=1 " +
+                    "to be accepted here."
                 },
                 execute: {
                   type: "boolean",
@@ -1845,13 +1864,33 @@ class ThreeDPrinterMCPServer {
           }
 
           case "check_fulu_orca_setup": {
+            const runBridgeProbe = Boolean(args?.run_bridge_probe ?? false);
             result = await inspectFuluOrcaSetup({
-              slicerPath: args?.slicer_path !== undefined ? String(args.slicer_path) : undefined,
-              pluginDir: args?.plugin_dir !== undefined ? String(args.plugin_dir) : undefined,
-              runtimeDir: args?.runtime_dir !== undefined ? String(args.runtime_dir) : undefined,
+              slicerPath: this.resolveBridgeExecutableSelectorArg(
+                args?.slicer_path,
+                "check_fulu_orca_setup",
+                "slicer_path",
+                runBridgeProbe
+              ),
+              pluginDir: this.resolveBridgeExecutableSelectorArg(
+                args?.plugin_dir,
+                "check_fulu_orca_setup",
+                "plugin_dir",
+                runBridgeProbe
+              ),
+              runtimeDir: this.resolveBridgeExecutableSelectorArg(
+                args?.runtime_dir,
+                "check_fulu_orca_setup",
+                "runtime_dir",
+                runBridgeProbe
+              ),
               platform: args?.platform !== undefined ? String(args.platform) : undefined,
-              bridgeCommand: args?.bridge_command !== undefined ? String(args.bridge_command) : undefined,
-              runBridgeProbe: Boolean(args?.run_bridge_probe ?? false),
+              bridgeCommand: this.resolveBridgeExecutableSelectorArg(
+                args?.bridge_command,
+                "check_fulu_orca_setup",
+                "bridge_command"
+              ),
+              runBridgeProbe,
               probeTimeoutMs:
                 args?.probe_timeout_ms !== undefined ? Number(args.probe_timeout_ms) : undefined,
             });
@@ -1875,8 +1914,11 @@ class ThreeDPrinterMCPServer {
                 : undefined;
 
             result = await invokeFuluBridgeRpc({
-              bridgeCommand:
-                args?.bridge_command !== undefined ? String(args.bridge_command) : undefined,
+              bridgeCommand: this.resolveBridgeExecutableSelectorArg(
+                args?.bridge_command,
+                "fulu_bambu_network_rpc",
+                "bridge_command"
+              ),
               method,
               payload,
               timeoutMs: args?.timeout_ms !== undefined ? Number(args.timeout_ms) : undefined,
@@ -1918,8 +1960,11 @@ class ThreeDPrinterMCPServer {
               stlPath: String(args.stl_path),
               operations: args.operations.map((entry) => String(entry)),
               execute: Boolean(args.execute ?? false),
-              bridgeCommand:
-                args.bridge_command !== undefined ? String(args.bridge_command) : undefined,
+              bridgeCommand: this.resolveBridgeExecutableSelectorArg(
+                args.bridge_command,
+                "blender_mcp_edit_model",
+                "bridge_command"
+              ),
             });
             break;
             
@@ -2238,6 +2283,35 @@ class ThreeDPrinterMCPServer {
     console.error(
       `3D Printer MCP server running on streamable-http at http://${this.runtimeConfig.httpHost}:${this.runtimeConfig.httpPort}${this.runtimeConfig.httpPath}`
     );
+  }
+
+  /**
+   * Bridge commands and path-derived bridge executables are machine-local
+   * settings. Accepting their selectors as tool arguments means anything that
+   * can steer the model — a model description, a README in a downloaded
+   * archive, 3MF metadata — can choose the program this server runs. They are
+   * read from environment configuration by default and only accepted for
+   * execution when MCP_ALLOW_BRIDGE_COMMAND_ARG is set.
+   */
+  private resolveBridgeExecutableSelectorArg(
+    rawValue: unknown,
+    toolName: string,
+    argumentName: string,
+    bridgeExecutionRequested = true
+  ): string | undefined {
+    if (rawValue === undefined) {
+      return undefined;
+    }
+
+    if (bridgeExecutionRequested && !this.runtimeConfig.allowBridgeCommandArg) {
+      throw new Error(
+        `${toolName}: the ${argumentName} argument cannot select a bridge executable by default. ` +
+        "Bridge executables and their paths are read from server environment configuration. Set " +
+        `MCP_ALLOW_BRIDGE_COMMAND_ARG=1 to accept ${argumentName} for bridge execution.`
+      );
+    }
+
+    return String(rawValue);
   }
 
   private async invokeBlenderBridge(params: {

--- a/tests/behavior.test.mjs
+++ b/tests/behavior.test.mjs
@@ -725,6 +725,7 @@ test("FULU setup check validates macOS runtime payload and probes bridge", async
       ...process.env,
       MCP_TRANSPORT: "stdio",
       BAMBU_MODEL: "",
+      MCP_ALLOW_BRIDGE_COMMAND_ARG: "1",
     },
     stderr: "pipe",
   });
@@ -777,6 +778,7 @@ test("FULU bridge RPC allows read-only methods and gates mutating print methods"
       MCP_TRANSPORT: "stdio",
       PRINTER_TYPE: "bambu",
       BAMBU_MODEL: "",
+      MCP_ALLOW_BRIDGE_COMMAND_ARG: "1",
     },
     stderr: "pipe",
   });
@@ -839,6 +841,138 @@ test("FULU bridge RPC allows read-only methods and gates mutating print methods"
   assert.equal(allowedPrintPayload.printMethod, true);
   assert.equal(allowedPrintPayload.bambuModel, "p1s");
   assert.equal(allowedPrintPayload.response.method, "net.start_print");
+});
+
+test("bridge_command argument is rejected by default and the env var still works", async (t) => {
+  const bridgeCommand = await createFakeFuluBridge(t);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY],
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: "stdio",
+      PRINTER_TYPE: "bambu",
+      BAMBU_MODEL: "",
+      FULU_BAMBU_BRIDGE_COMMAND: bridgeCommand,
+      // Empty rather than "0" so this exercises the shipped default.
+      MCP_ALLOW_BRIDGE_COMMAND_ARG: "",
+    },
+    stderr: "pipe",
+  });
+
+  const client = createClient();
+
+  t.after(async () => {
+    await closeTransport(transport);
+  });
+
+  await client.connect(transport);
+
+  // The argument is refused on every tool that reaches a bridge spawn.
+  for (const call of [
+    { name: "check_fulu_orca_setup", arguments: { bridge_command: bridgeCommand, run_bridge_probe: true } },
+    { name: "fulu_bambu_network_rpc", arguments: { bridge_command: bridgeCommand, method: "bridge.ping" } },
+    {
+      name: "blender_mcp_edit_model",
+      arguments: {
+        stl_path: SAMPLE_STL,
+        operations: ["remesh"],
+        execute: true,
+        bridge_command: bridgeCommand,
+      },
+    },
+  ]) {
+    const rejected = await client.callTool(call);
+    assert.equal(rejected.isError, true, `${call.name} must reject bridge_command by default`);
+    assert.match(
+      rejected.content?.[0]?.text || "",
+      /MCP_ALLOW_BRIDGE_COMMAND_ARG/,
+      `${call.name} must name the opt-in env var so the fix is discoverable`
+    );
+  }
+
+  // The capability itself is untouched: the env var still drives the bridge.
+  const viaEnv = await client.callTool({
+    name: "fulu_bambu_network_rpc",
+    arguments: { method: "bridge.ping" },
+  });
+  assert.equal(viaEnv.isError, undefined, "FULU_BAMBU_BRIDGE_COMMAND must still reach the bridge");
+  assert.equal(parseJsonResult(viaEnv).response.value, "pong");
+});
+
+test("bridge probes reject every per-call executable path selector by default", async (t) => {
+  const bundle = await createFakeFuluBundle(t);
+  const markerPath = path.join(path.dirname(bundle.pluginDir), "unexpected-bridge-execution");
+  await fs.writeFile(
+    path.join(bundle.pluginDir, "pjarczak-bambu-linux-host-wrapper"),
+    `#!/bin/sh\nprintf executed > '${markerPath}'\nexit 0\n`,
+    { mode: 0o755 }
+  );
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY],
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: "stdio",
+      PRINTER_TYPE: "bambu",
+      BAMBU_MODEL: "",
+      FULU_BAMBU_BRIDGE_COMMAND: "",
+      FULU_ORCA_PLUGIN_DIR: "",
+      ORCASLICER_BAMBULAB_PLUGIN_DIR: "",
+      MCP_ALLOW_BRIDGE_COMMAND_ARG: "",
+    },
+    stderr: "pipe",
+  });
+
+  const client = createClient();
+
+  t.after(async () => {
+    await closeTransport(transport);
+  });
+
+  await client.connect(transport);
+
+  for (const [argumentName, argumentValue] of [
+    ["slicer_path", bundle.slicerPath],
+    ["plugin_dir", bundle.pluginDir],
+    ["runtime_dir", bundle.runtimeDir],
+  ]) {
+    const rejected = await client.callTool({
+      name: "check_fulu_orca_setup",
+      arguments: {
+        platform: "darwin",
+        [argumentName]: argumentValue,
+        run_bridge_probe: true,
+      },
+    });
+    assert.equal(
+      rejected.isError,
+      true,
+      `${argumentName} must not select a spawned executable without the explicit opt-in`
+    );
+    assert.match(rejected.content?.[0]?.text || "", new RegExp(argumentName));
+    assert.match(rejected.content?.[0]?.text || "", /MCP_ALLOW_BRIDGE_COMMAND_ARG/);
+  }
+
+  assert.equal(
+    await fs.access(markerPath).then(() => true, () => false),
+    false,
+    "a rejected path override must not execute the derived bridge command"
+  );
+
+  const inspection = await client.callTool({
+    name: "check_fulu_orca_setup",
+    arguments: {
+      platform: "darwin",
+      slicer_path: bundle.slicerPath,
+      plugin_dir: bundle.pluginDir,
+      runtime_dir: bundle.runtimeDir,
+      run_bridge_probe: false,
+    },
+  });
+  assert.equal(inspection.isError, undefined, "path overrides remain available for non-executing inspection");
+  assert.equal(parseJsonResult(inspection).status, "ready");
 });
 
 test("printer model safety: BAMBU_MODEL env var accepted as default", async (t) => {


### PR DESCRIPTION
## Summary

Read bridge executable selection from server environment configuration by default. Per-call executable selectors are available only when the operator explicitly sets `MCP_ALLOW_BRIDGE_COMMAND_ARG=1`.

This preserves the diagnostic capability while preventing prompt-injected third-party content from choosing a local program for the server to spawn.

## What changes

- `bridge_command` is rejected by default on:
  - `check_fulu_orca_setup`
  - `fulu_bambu_network_rpc`
  - `blender_mcp_edit_model`
- A live `check_fulu_orca_setup` probe also rejects per-call `slicer_path`, `plugin_dir`, and `runtime_dir`, because those paths can derive the spawned bridge executable.
- Non-executing setup inspection can still use those paths without the opt-in.
- `FULU_BAMBU_BRIDGE_COMMAND`, `BLENDER_MCP_BRIDGE_COMMAND`, and environment-configured FULU paths continue to work by default.
- `MCP_ALLOW_BRIDGE_COMMAND_ARG=1` restores per-call diagnostic overrides.
- Documentation and tool descriptions explain the boundary.
- The package version is bumped to `1.2.7`.

## Why

The relevant boundary is not remote access to local stdio. Tool arguments are selected by the model, whose context may contain untrusted MakerWorld descriptions, archive READMEs, 3MF metadata, and filenames. Without this gate, content that steers a tool call can also choose the program spawned with `shell: true`.

## Testing

- `npm run build`
- `node --test tests/behavior.test.mjs` — 13/13 pass
- `npm test` — pass

Regression coverage verifies:

- direct `bridge_command` arguments are rejected on all three tools by default;
- every path capable of deriving a FULU probe executable is rejected by default;
- rejected overrides produce no executable side effect;
- non-executing path inspection remains available;
- environment-configured bridge execution and the explicit diagnostic opt-in continue to work.
